### PR TITLE
"r.js" isn't a really good name for a command

### DIFF
--- a/requirejs/package.json
+++ b/requirejs/package.json
@@ -20,7 +20,8 @@
     },
     "main": "./bin/r.js",
     "bin": {
-        "r.js": "./bin/r.js"
+        "r.js": "./bin/r.js",
+        "r_js": "./bin/r.js"
     },
     "engines": {
         "node": ">=0.4.0"


### PR DESCRIPTION
It doesn't work for Windows. Because of the js extension, Windows tries to execute a program associated with js files. That's why to actually run r.js, it's necessarily to type `r.js.cmd` in the command line. Isn't it better if the command name is the same on different operation systems?