### PR TITLE
Add "browser" alternative path to package.json

### DIFF
--- a/requirejs/package.json
+++ b/requirejs/package.json
@@ -10,6 +10,7 @@
         "url": "https://github.com/jrburke/r.js.git"
     },
     "main": "./bin/r.js",
+    "browser": "./require.js",
     "bin": {
         "r.js": "./bin/r.js",
         "r_js": "./bin/r.js"


### PR DESCRIPTION
Recently ran into an issue with the npm version of requirejs where I was accidentally pushing the compiled version (r.js) to browser clients because of a generic script redirector checking node_module packages for their main paths.

This redirector checks for "browser" first and then falls back to "main" (or defaults to either "index.js" or "{name}.js" if that's missing).

I'm just recently trying to get back into the webdev game, so please let me know if there's a history here or any reason that the "browser" field hasn't seen wider adoption! It seems like a great generic solution to packaging and delivery problems.